### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "environment"
   ],
   "main": "index.js",
-  "module": "src/index.js",
+  "module": "index.js",
   "author": "Matthew Turnbull <turnbullm@gmail.com> (http://turnbullm.com)",
   "license": "MIT",
   "homepage": "https://github.com/turnbullm/configrrr",


### PR DESCRIPTION
When compiling using Angular CLI it is bundling based on the `module` path, and not `main`. I don't fully understand the difference, but looking at other packages I see they point `module` points at production bundled code and not source